### PR TITLE
fix(suggest): use `updateMessage` after `yield`

### DIFF
--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -199,8 +199,6 @@ export class UserCommand extends Command {
 	}
 
 	private async *handleEdit(interaction: Command.Interaction, id: number, input: string): Command.GeneratorResponse {
-		yield this.defer({ flags: MessageFlags.Ephemeral });
-
 		const guildId = BigInt(interaction.guild_id!);
 		const suggestion = await this.container.prisma.suggestion.findUnique({
 			where: { id_guildId: { id, guildId } }
@@ -244,6 +242,8 @@ export class UserCommand extends Command {
 			return this.message({ content, flags: MessageFlags.Ephemeral });
 		}
 
+		yield this.defer({ flags: MessageFlags.Ephemeral });
+
 		const result = await fromAsync(ChannelId.MessageId.get(settings.channel, suggestion.messageId));
 		if (!result.success) {
 			await this.container.prisma.suggestion.update({
@@ -252,7 +252,7 @@ export class UserCommand extends Command {
 			});
 
 			const content = resolveUserKey(interaction, LanguageKeys.Commands.Suggest.ModifyMessageDeleted);
-			return this.message({ content, flags: MessageFlags.Ephemeral });
+			return this.updateMessage({ content, flags: MessageFlags.Ephemeral });
 		}
 
 		input = await useEmbedContent(input, guildId, settings.channel);


### PR DESCRIPTION
This bug caused a payload format mismatch, which in turn made errors return `DiscordAPIError[50006]: Cannot send an empty message`.

I also moved the `yield` in `handleEdit` to vastly reduce response time on errors.