### PR TITLE
fix: use followup instead of reply

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
 	},
 	"packageManager": "yarn@3.2.4",
 	"volta": {
-		"node": "18.8.0"
+		"node": "18.12.0"
 	}
 }

--- a/src/interaction-handlers/suggestions-modal.ts
+++ b/src/interaction-handlers/suggestions-modal.ts
@@ -34,6 +34,6 @@ export class Handler extends InteractionHandler {
 			{ id }
 		);
 
-		return interaction.reply({ content, flags: MessageFlags.Ephemeral });
+		return interaction.followup({ content, flags: MessageFlags.Ephemeral });
 	}
 }


### PR DESCRIPTION
Resolves a crash with the message of `Cannot send response, the request has already been replied.` by calling `.followup`, which does a REST query sending a new message.
