### PR TITLE
fix: resolved custom emoji parser

### DIFF
--- a/src/lib/utilities/serialized-emoji.ts
+++ b/src/lib/utilities/serialized-emoji.ts
@@ -51,7 +51,7 @@ export function getReactionFormat(emoji: SerializedEmoji) {
 
 // Twemoji keycaps and Unicode emojis:
 const twemoji = /^(?:\d\ufe0f?\u20e3|\p{Emoji_Presentation})$/u;
-const customEmoji = /<(?<animated>a)?:(?<name>\w{2,32}):(?<id>\d{17,18})>/;
+const customEmoji = /<(?<animated>a)?:(?<name>[a-zA-Z0-9_]{2,32}):(?<id>\d{17,19})>/;
 export function parse(emoji: string): SerializedEmoji | null {
 	if (twemoji.test(emoji)) return `t${emoji}`;
 


### PR DESCRIPTION
- Discord emoji names can only be alphanumeric (`[a-zA-Z0-9]`) or underscore (`_`), however, we used `\w` which also allowed `-`, this is not a valid emoji name.
- New emojis have 19-digit IDs, I somehow missed this.
