### PR TITLE
fix: don't duplicate the buffer

### DIFF
--- a/src/lib/utilities/suggestion-utilities.ts
+++ b/src/lib/utilities/suggestion-utilities.ts
@@ -204,7 +204,7 @@ export async function useEmbedContent(content: string, guildId: Snowflake, chann
 
 		if (result.index !== lastIndex) {
 			buffer += content.slice(lastIndex, result.index);
-			if (buffer.length) parts.push(buffer + content.slice(lastIndex, result.index));
+			if (buffer.length) parts.push(buffer);
 
 			buffer = '';
 		}


### PR DESCRIPTION
Writing `Duplicate of #22` resulted on `Duplicate of Duplicate of #22` due to the double slice. I removed it and now works fine.
